### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,21 @@
+name: Publish
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - run: npm ci
+      - run: npm run build
+      - uses: JasonEtco/build-and-tag-action@v1
+        with:
+          setup: ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds the Actions workflow to auto-build and publish new versions to the marketplace when a new tag is pushed.