### PR TITLE
Order closable issues by least-recently updated

### DIFF
--- a/src/no-response.ts
+++ b/src/no-response.ts
@@ -133,7 +133,7 @@ export default class NoResponse {
     const issues = await this.octokit.search.issuesAndPullRequests({
       q,
       sort: 'updated',
-      order: 'desc',
+      order: 'asc',
       per_page: 30
     })
 


### PR DESCRIPTION
When checking for issues to close, get the 30 least-recently updated issues, rather than the 30 most-recently updated issues.

Fixes https://github.com/lee-dohm/no-response/issues/190