### PR TITLE
Execute action using node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ inputs:
     description: Token to access the GitHub API
     required: true
 runs:
-  using: node12
+  using: node16
   main: 'dist/index.js'


### PR DESCRIPTION
Attempt to upgrade to node16, as node 12 actions are marked deprecated by github.

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: lee-dohm/no-response

