### PR TITLE
Fix error handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,9 +11,9 @@ async function run(): Promise<void> {
     const noResponse = new NoResponse(config)
 
     if (eventName === 'schedule') {
-      noResponse.sweep()
+      await noResponse.sweep()
     } else if (eventName === 'issue_comment') {
-      noResponse.unmark()
+      await noResponse.unmark()
     } else {
       core.error(`Unrecognized event: ${eventName}`)
     }


### PR DESCRIPTION
These are promises, we need to use `await` to be able to catch the errors. For example, in https://github.com/mui/mui-x/actions/runs/3350385087/jobs/5551157153 the job failed but is marked as successful 🙈.

(The job failed because MUI didn't set the right permissions, we use "Default access restricted" in https://docs.github.com/en/actions/security-guides/automatic-token-authentication).

Context: https://github.com/mui/mui-x/pull/6658